### PR TITLE
feat: add Claude Code project settings and slash commands

### DIFF
--- a/.claude/commands/new-agent.md
+++ b/.claude/commands/new-agent.md
@@ -1,0 +1,59 @@
+# New Agent
+
+Create a new agent definition file in `.claude/agents/` with proper frontmatter and behavior instructions.
+
+## Instructions
+
+You will create a new agent definition for **$ARGUMENTS**.
+
+---
+
+### Step 1 — Read existing agents
+
+Before writing anything, read two or three existing agent files in `.claude/agents/` (e.g. `orchestrator.md`, `researcher.md`, `planner.md`) to understand the frontmatter format and instruction style.
+
+Also read `CLAUDE.md` for:
+- The required frontmatter fields (`name`, `description`, `model`, `tools`)
+- Model selection cost guardrails (haiku for read/report, sonnet for implementation/review, opus only with justification)
+
+### Step 2 — Determine the agent's role
+
+Based on the name provided, identify:
+- **What trigger or pipeline stage** invokes this agent
+- **What inputs** it receives (e.g. a RESEARCH BRIEF, an issue summary, a diff)
+- **What structured output** it produces (e.g. IMPLEMENTATION PLAN, UNIT TEST RESULT)
+- **What tools** it needs (use the minimum necessary set)
+- **Which model tier** is appropriate per CLAUDE.md cost guardrails
+
+### Step 3 — Create the agent file
+
+File: `.claude/agents/<name>.md`
+
+The file must begin with this exact frontmatter:
+
+```yaml
+---
+name: <slug matching filename without .md>
+description: >
+  <multi-line description used by the orchestrator to route tasks>
+model: <full model ID: claude-haiku-4-5-20251001 | claude-sonnet-4-6 | claude-opus-4-6>
+tools:
+  - <Tool>
+---
+```
+
+Rules:
+- `name` must exactly match the filename without `.md`
+- `description` must be a clear, specific summary the orchestrator can use to decide when to invoke this agent — not a generic statement
+- Do not add extra frontmatter keys, reorder fields, or omit `description` or `tools`
+- Choose the minimum tool set required; do not add tools speculatively
+
+After the frontmatter, write the agent's behavior instructions:
+- State the agent's single responsibility clearly in the first paragraph
+- Define what structured input it expects
+- Define the exact structured output format it must produce (use a code block)
+- List any constraints or failure conditions
+
+### Step 4 — Confirm
+
+Show the created file path and frontmatter, and explain how the orchestrator would route tasks to this agent.

--- a/.claude/commands/new-workflow.md
+++ b/.claude/commands/new-workflow.md
@@ -1,0 +1,71 @@
+# New Workflow
+
+Create a complete new agentic workflow following the repo conventions in CLAUDE.md.
+
+## Instructions
+
+You will create three artifacts for a new workflow named **$ARGUMENTS**:
+
+1. **Reusable workflow** at `.github/workflows/<name>.yml`
+2. **Consumer example** at `examples/consumer-workflows/agentic-<name>.yml`
+3. **Test file** at `tests/test_<name>.py`
+
+Then update `scaffold/bootstrap.sh` and `README.md`.
+
+---
+
+### Step 1 — Read existing conventions
+
+Before writing anything, read:
+- `CLAUDE.md` for naming conventions, required inputs/secrets, and prompt structure
+- An existing reusable workflow (e.g. `.github/workflows/pr-review.yml`) as a structural reference
+- Its matching consumer example (e.g. `examples/consumer-workflows/agentic-pr-review.yml`)
+- `scaffold/bootstrap.sh` to understand the WORKFLOWS array format
+
+### Step 2 — Create the reusable workflow
+
+File: `.github/workflows/<name>.yml`
+
+Requirements:
+- `on: workflow_call` with explicit `inputs:` and `secrets:` blocks
+- Required inputs: `model` (default `"claude-sonnet-4-6"`), `claude_args` (default `""`)
+- Required secret: `ANTHROPIC_API_KEY`
+- `timeout-minutes: 30` on the job
+- Comment block at the top: workflow name, one-line description, usage example
+- Uses `actions/checkout@v4` with `fetch-depth: 0`
+- Uses `anthropics/claude-code-action@v1`
+- Prompt structured with `##` headers and numbered steps
+- Ends with `## Agent override` section pointing to `.claude/agents/<name>.md` in the consumer repo
+- Select model tier per CLAUDE.md cost guardrails (haiku for lightweight read/report, sonnet for implementation/review, opus only with written justification)
+
+### Step 3 — Create the consumer example
+
+File: `examples/consumer-workflows/agentic-<name>.yml`
+
+Requirements:
+- Thin caller: triggers, concurrency group, single job that calls the reusable workflow via `uses:`
+- Concurrency group pattern: `agentic-<name>-${{ github.ref }}`
+- Commented-out `with:` lines showing common customizations
+- Comment at top noting `ANTHROPIC_API_KEY` requirement and optional agent override file path
+
+### Step 4 — Create the test file
+
+File: `tests/test_<name>.py`
+
+Requirements:
+- Validate prompt structure (required `##` sections are present)
+- Validate required inputs exist in the workflow YAML (`model`, `claude_args`, `ANTHROPIC_API_KEY`)
+- Validate any shell logic in non-Claude steps
+- Follow the pattern of existing test files in `tests/`
+
+### Step 5 — Update supporting files
+
+In `scaffold/bootstrap.sh`: append `"agentic-<name>.yml"` to the `WORKFLOWS` array.
+
+In `README.md`:
+- Add a row to the Workflows table
+- Add a row to the Cost Considerations table with model tier and estimated token/cost range
+
+### Step 6 — Confirm
+
+List all files created or modified and summarize what each one does.

--- a/.claude/commands/run-pipeline.md
+++ b/.claude/commands/run-pipeline.md
@@ -1,0 +1,85 @@
+# Run Pipeline
+
+Walk a GitHub issue through all pipeline stages using the agentic engineering workflow.
+
+## Instructions
+
+Run the full pipeline for issue **$ARGUMENTS**.
+
+---
+
+### Step 1 — Load context
+
+Read:
+- `CLAUDE.md` for pipeline conventions and agent override pattern
+- `.claude/agents/orchestrator.md` for routing rules and stage definitions
+
+### Step 2 — Fetch the issue
+
+Retrieve the issue using `gh issue view <number> --json number,title,body,labels,assignees`.
+
+Parse the issue to identify:
+- The stated goal or feature request
+- Acceptance criteria (explicit or implicit)
+- Any labels that affect routing (e.g. `bug`, `enhancement`, `chore`)
+
+### Step 3 — Clarify (Stage 1)
+
+Delegate to the `clarifier` agent.
+
+- If clarifier returns unresolved questions, halt here and surface them as a comment on the issue. Do not proceed until the questions are answered.
+- If clarifier confirms the issue is unambiguous, proceed.
+
+Skip clarification only if the issue already contains explicit acceptance criteria and no ambiguous scope.
+
+### Step 4 — Research (Stage 2)
+
+Delegate to the `researcher` agent. Pass:
+- The clarified issue summary
+- Any answers provided to clarifier questions
+
+Researcher produces a RESEARCH BRIEF. Validate that the brief contains: scope, affected files, risks, and open questions.
+
+### Step 5 — Plan (Stage 3)
+
+Delegate to the `planner` agent. Pass the RESEARCH BRIEF.
+
+Planner produces an IMPLEMENTATION PLAN. The plan must include: approach, files to change, test strategy, and rollback notes. Do not proceed without a complete plan.
+
+### Step 6 — Implement (Stage 4)
+
+Delegate to the `programmer` agent. Pass the IMPLEMENTATION PLAN.
+
+Programmer writes code and runs the quality gate. If the quality gate fails, pass the failure back to `remediator` and retry up to 2 times before halting.
+
+### Step 7 — Test (Stage 5)
+
+Run in parallel where possible:
+- Delegate to `unit-tester` for unit tests
+- Delegate to `test-integration` if the change touches API contracts or database schemas
+- Delegate to `test-e2e` if the change has a UI surface
+
+Skip `test-e2e` for pure backend or library changes. Skip `test-integration` for changes with no API or schema impact.
+
+All test agents must return PASS before proceeding.
+
+### Step 8 — Review (Stage 6)
+
+Delegate to `ai-reviewer`. If reviewer returns CHANGES REQUIRED, delegate to `remediator` then re-run `ai-reviewer`. Repeat up to 3 cycles. If still failing after 3 cycles, halt and escalate.
+
+### Step 9 — Create PR (Stage 7)
+
+Delegate to `pr-creator`. Pass the issue number, branch name, and pipeline summary.
+
+### Step 10 — Report
+
+Output the structured pipeline result:
+
+```
+PIPELINE RESULT: [COMPLETE | HALTED]
+ISSUE: #<number>
+STAGES: <comma-separated list of completed stages>
+SKIPPED: <comma-separated list with reason, or "none">
+PR: <url or "not created">
+NOTES: <any important context for human reviewer>
+```

--- a/.claude/commands/validate-all.md
+++ b/.claude/commands/validate-all.md
@@ -1,0 +1,84 @@
+# Validate All
+
+Run all tests, lint all YAML, and validate all agent frontmatter in the repo.
+
+## Instructions
+
+Perform a full validation sweep. Report failures clearly; do not stop at the first failure — collect all issues before summarizing.
+
+---
+
+### Step 1 — Run the test suite
+
+```bash
+pytest tests/ -v 2>&1
+```
+
+Record: number of tests passed, failed, and any error output.
+
+### Step 2 — Lint all workflow YAML
+
+For every file in `.github/workflows/` and `examples/consumer-workflows/`:
+
+```bash
+python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" <file>
+```
+
+Or use `yamllint` if available:
+
+```bash
+yamllint .github/workflows/ examples/consumer-workflows/
+```
+
+Record: any files that fail to parse or have lint warnings.
+
+### Step 3 — Validate agent frontmatter
+
+For every file in `.claude/agents/`:
+
+Check that the frontmatter:
+1. Is present (file starts with `---`)
+2. Contains exactly these fields: `name`, `description`, `model`, `tools`
+3. `name` matches the filename without `.md`
+4. `model` is one of: `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus-4-6`
+5. `tools` is a non-empty list
+
+Report any agent file that fails any check.
+
+### Step 4 — Validate workflow inventory
+
+Cross-check that every reusable workflow in `.github/workflows/` has:
+- A matching consumer example in `examples/consumer-workflows/agentic-<name>.yml`
+- A matching test file in `tests/test_<name>.py`
+- An entry in `scaffold/bootstrap.sh`'s `WORKFLOWS` array
+- A row in the README.md Workflows table
+
+Report any workflow that is missing any of these.
+
+### Step 5 — Validate consumer examples
+
+For every file in `examples/consumer-workflows/`:
+- Filename must start with `agentic-`
+- Must contain a `uses:` reference to the matching reusable workflow
+- Must define a `concurrency:` group
+
+Report any consumer example that fails these checks.
+
+### Step 6 — Summary report
+
+Output a structured report:
+
+```
+VALIDATION RESULT: [PASS | FAIL]
+
+Tests:         <N passed, N failed>
+YAML lint:     <N files ok, N files failed>
+Agent frontmatter: <N valid, N invalid>
+Workflow inventory: <N complete, N missing artifacts>
+Consumer examples: <N valid, N invalid>
+
+ISSUES:
+- <file>: <description of problem>
+```
+
+If all checks pass, output `VALIDATION RESULT: PASS` with counts. If any check fails, output `VALIDATION RESULT: FAIL` and list every issue found.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "allowedTools": [
+    "Read",
+    "Write",
+    "Edit",
+    "Bash",
+    "Glob",
+    "Grep",
+    "Agent",
+    "WebSearch",
+    "WebFetch",
+    "mcp__claude_ai_Linear__get_issue",
+    "mcp__claude_ai_Linear__list_issues",
+    "mcp__claude_ai_Linear__save_issue",
+    "mcp__claude_ai_Linear__save_comment",
+    "mcp__claude_ai_Linear__list_comments",
+    "mcp__claude_ai_Linear__get_project",
+    "mcp__claude_ai_Linear__list_projects"
+  ],
+  "model": "claude-sonnet-4-6",
+  "projectContext": [
+    "CLAUDE.md",
+    "AGENTS.md"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,19 @@ gh secret set ANTHROPIC_API_KEY --org <your-org> --visibility all
 
 ---
 
+## Claude Code Commands
+
+Project-specific slash commands live in `.claude/commands/`. Invoke them with `/project:<name>` in Claude Code.
+
+| Command | Usage | What it does |
+|---|---|---|
+| `new-workflow` | `/project:new-workflow <name>` | Creates a reusable workflow, consumer example, and test file for a new workflow named `<name>`. Also updates `scaffold/bootstrap.sh` and `README.md`. |
+| `new-agent` | `/project:new-agent <name>` | Creates a new `.claude/agents/<name>.md` file with correct frontmatter and behavior instructions. |
+| `run-pipeline` | `/project:run-pipeline <issue-number>` | Walks a GitHub issue through all pipeline stages (clarify → research → plan → implement → test → review → PR). |
+| `validate-all` | `/project:validate-all` | Runs the test suite, lints all workflow YAML, validates all agent frontmatter, and cross-checks the workflow inventory. |
+
+---
+
 ## Contribution Guidelines
 
 - **Read before editing.** Understand an existing workflow fully before modifying it.


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with `allowedTools`, default model (`claude-sonnet-4-6`), and Linear MCP tool permissions
- Adds four project slash commands under `.claude/commands/`:
  - `/project:new-workflow <name>` — scaffolds a complete workflow (reusable + consumer + test + README/bootstrap updates)
  - `/project:new-agent <name>` — creates an agent definition with correct frontmatter
  - `/project:run-pipeline <issue-number>` — walks a GitHub issue through all 7 pipeline stages
  - `/project:validate-all` — runs tests, YAML lint, agent frontmatter validation, and workflow inventory check
- Documents all commands in a new `## Claude Code Commands` section in `CLAUDE.md`

## Test plan

- [ ] Run `/project:validate-all` in a Claude Code session and confirm it reports PASS on the current repo state
- [ ] Run `/project:new-agent test-agent` and confirm the generated file has valid frontmatter
- [ ] Run `/project:new-workflow smoke-test` and confirm all expected files are created
- [ ] Verify `.claude/settings.json` is recognized by Claude Code (check allowed tools in a session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)