### PR TITLE
fix: remove pull_request_review trigger and add skipped-run cleanup

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,8 +7,13 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  # pull_request_review intentionally omitted: Copilot submits these in bulk,
+  # generating hundreds of skipped run records. @claude in inline comments is
+  # captured by pull_request_review_comment; review-body @claude mentions are rare.
+
+concurrency:
+  group: claude-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   claude:
@@ -16,7 +21,6 @@ jobs:
       github.event.sender.type != 'Bot' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-skipped-runs.yml
+++ b/.github/workflows/cleanup-skipped-runs.yml
@@ -1,0 +1,22 @@
+name: Cleanup skipped Claude Code runs
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # 6am UTC daily
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete skipped Claude Code runs older than 24h
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/workflows/claude.yml/runs" \
+            --paginate \
+            --jq '.workflow_runs[] | select(.conclusion == "skipped") | .id' \
+          | xargs -r -I{} gh api --method DELETE \
+            "repos/${{ github.repository }}/actions/runs/{}"


### PR DESCRIPTION
## Problem

Copilot submits PR reviews in bulk, each triggering `claude.yml` via the `pull_request_review` event. GitHub creates a run record for every trigger even when the job is skipped — resulting in hundreds of cluttered skipped runs on the Actions page.

## Changes

### `claude.yml`
- Remove `pull_request_review` from triggers — inline `@claude` mentions are still captured by `pull_request_review_comment`; review-body mentions are rare enough not to warrant the spam
- Remove the corresponding `pull_request_review` branch from the `if` condition
- Add `concurrency` group to auto-cancel duplicate runs for the same PR/issue

### `cleanup-skipped-runs.yml` (new)
- Daily cron (6am UTC) + `workflow_dispatch`
- Deletes all skipped `claude.yml` runs via the GitHub API
- Acts as a long-term hygiene backstop in case other triggers generate skipped runs in future

## Why not just fix the `if` condition?

GitHub creates run records at event receipt, before `if` conditions are evaluated. Removing the trigger entirely is the only way to prevent the records from being created.