### PR TITLE
fix(workflows): make issue-to-pr idempotent on re-runs

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -51,7 +51,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check idempotency
+        id: idempotency
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+
+          # Exit early if a PR already exists for this issue (open or merged)
+          EXISTING_PR=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --search "Closes #${ISSUE_NUMBER} in:body" \
+            --state all \
+            --json number,url,state \
+            --jq '.[0] | select(. != null) | "\(.state) \(.url)"' 2>/dev/null || true)
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "PR already exists for issue #${ISSUE_NUMBER}: ${EXISTING_PR}"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Claude Issue-to-PR Pipeline
+        if: steps.idempotency.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -78,12 +101,13 @@ jobs:
 
             ## Phase 2: Plan
 
-            4. Create a feature branch:
+            4. Create or resume a feature branch:
                ```bash
                ISSUE_ID=${{ github.event.issue.number }}
                SLUG=$(gh issue view $ISSUE_ID --json title -q '.title' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | head -c 40)
                BRANCH="issue-${ISSUE_ID}-${SLUG}"
-               git checkout -b "$BRANCH"
+               # Use -b to create; fall back to checkout if branch already exists
+               git checkout -b "$BRANCH" || git checkout "$BRANCH"
                ```
 
             5. Analyze the codebase to understand what needs to change:


### PR DESCRIPTION
Add an idempotency guard step that checks whether a PR already exists for the issue (open or merged) before invoking the Claude agent. If one is found, the step sets skip=true and the Claude step is skipped entirely.

Also change `git checkout -b "$BRANCH"` to
`git checkout -b "$BRANCH" || git checkout "$BRANCH"` so that a re-run on an already-created branch doesn't hard-fail before Claude even starts.

Fixes the failure seen in run 23408660301 (attempt 4), which errored because attempt 3 had already succeeded and the branch/PR existed.

https://claude.ai/code/session_01PhXLB5YUffQKRH2NQca89V